### PR TITLE
add WalEventRouter based on log4j

### DIFF
--- a/producer/pom.xml
+++ b/producer/pom.xml
@@ -23,7 +23,17 @@
             <artifactId>neo4j-streams-common</artifactId>
             <version>3.5.3</version>
         </dependency>
-        
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.26</version>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/producer/src/main/kotlin/streams/StreamsEventRouter.kt
+++ b/producer/src/main/kotlin/streams/StreamsEventRouter.kt
@@ -18,8 +18,8 @@ abstract class StreamsEventRouter(val logService: LogService?, val config: Confi
 
 object StreamsEventRouterFactory {
     fun getStreamsEventRouter(logService: LogService, config: Config): StreamsEventRouter {
-        return Class.forName(config.raw.getOrDefault("streams.router", "streams.kafka.KafkaEventRouter"))
-                .getConstructor(LogService::class.java, Config::class.java)
+        return Class.forName(config.raw.getOrDefault("streams.router", "streams.wal.WalEventRouter"))
+        .getConstructor(LogService::class.java, Config::class.java)
                 .newInstance(logService, config) as StreamsEventRouter
     }
 }

--- a/producer/src/main/kotlin/streams/StreamsExtensionFactory.kt
+++ b/producer/src/main/kotlin/streams/StreamsExtensionFactory.kt
@@ -55,7 +55,7 @@ class StreamsEventRouterLifecycle(val db: GraphDatabaseAPI, val streamHandler: S
     private fun registerTransactionEventHandler() {
         if (streamsEventRouterConfiguration.enabled) {
             streamsConstraintsService = StreamsConstraintsService(db, streamsEventRouterConfiguration.schemaPollingInterval)
-            txHandler = StreamsTransactionEventHandler(streamHandler, streamsConstraintsService, streamsEventRouterConfiguration)
+            txHandler = StreamsTransactionEventHandler(streamHandler, streamsConstraintsService, streamsEventRouterConfiguration, streamsLog)
             db.registerTransactionEventHandler(txHandler)
             availabilityGuard.addListener(object: AvailabilityListener {
                 override fun unavailable() {}

--- a/producer/src/main/kotlin/streams/StreamsTransactionEventHandler.kt
+++ b/producer/src/main/kotlin/streams/StreamsTransactionEventHandler.kt
@@ -2,6 +2,7 @@ package streams
 
 import org.neo4j.graphdb.event.TransactionData
 import org.neo4j.graphdb.event.TransactionEventHandler
+import org.neo4j.logging.Log
 import streams.events.*
 import streams.extensions.labelNames
 import streams.utils.SchemaUtils.getNodeKeys
@@ -11,7 +12,8 @@ import java.util.concurrent.atomic.AtomicInteger
 
 class StreamsTransactionEventHandler(private val router: StreamsEventRouter,
                                      private val streamsConstraintsService: StreamsConstraintsService,
-                                     private val configuration: StreamsEventRouterConfiguration)
+                                     private val configuration: StreamsEventRouterConfiguration,
+                                     private val log: Log)
     : TransactionEventHandler<PreviousTransactionData> {
 
     /**

--- a/producer/src/main/kotlin/streams/wal/WalEventRouter.kt
+++ b/producer/src/main/kotlin/streams/wal/WalEventRouter.kt
@@ -1,0 +1,28 @@
+package streams.wal
+
+import org.neo4j.kernel.configuration.Config
+import org.neo4j.logging.internal.LogService
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import streams.StreamsEventRouter
+import streams.events.StreamsEvent
+import streams.serialization.JSONUtils
+
+class WalEventRouter(logService: LogService, config: Config) : StreamsEventRouter(logService, config) {
+    private val log: Logger = LoggerFactory.getLogger("TransactionLog")
+
+    override fun sendEvents(topic: String, transactionEvents: List<out StreamsEvent>) {
+        transactionEvents.forEach {
+            val event = JSONUtils.writeValueAsString(it)
+            log.info(event)
+        }
+    }
+
+    override fun start() {
+    }
+
+    override fun stop() {
+    }
+
+
+}

--- a/producer/src/main/resources/log4j.properties
+++ b/producer/src/main/resources/log4j.properties
@@ -1,0 +1,13 @@
+log4j.rootLogger=INFO
+
+# wal
+log4j.logger.TransactionLog=INFO, transactionFile
+log4j.additivity.TransactionLog=false
+log4j.appender.transactionFile=org.apache.log4j.RollingFileAppender
+log4j.appender.transactionFile.ImmediateFlush=true
+log4j.appender.transactionFile.Append=true
+log4j.appender.transactionFile.File=logs/transaction-events.log
+log4j.appender.transactionFile.MaxFileSize=256MB
+log4j.appender.transactionFile.MaxBackupIndex=16
+log4j.appender.transactionFile.layout=org.apache.log4j.PatternLayout
+log4j.appender.transactionFile.layout.ConversionPattern=%m%n

--- a/producer/src/test/kotlin/streams/StreamsTransactionEventHandlerRelTest.kt
+++ b/producer/src/test/kotlin/streams/StreamsTransactionEventHandlerRelTest.kt
@@ -16,6 +16,8 @@ import org.neo4j.graphdb.schema.ConstraintDefinition
 import org.neo4j.graphdb.schema.ConstraintType
 import org.neo4j.graphdb.schema.Schema
 import org.neo4j.kernel.internal.GraphDatabaseAPI
+import org.neo4j.logging.internal.LogService
+import org.neo4j.logging.internal.NullLogService
 import streams.events.*
 import streams.events.StreamsConstraintType
 import streams.mocks.MockStreamsEventRouter
@@ -42,7 +44,7 @@ class StreamsTransactionEventHandlerRelTest {
         streamsConstraintsService = StreamsConstraintsService(dbMock, 0)
         streamsConstraintsService.start()
         handler = StreamsTransactionEventHandler(MockStreamsEventRouter(),
-                streamsConstraintsService, StreamsEventRouterConfiguration())
+                streamsConstraintsService, StreamsEventRouterConfiguration(), NullLogService.getInstance().nullLog)
         MockStreamsEventRouter.reset()
     }
 

--- a/producer/src/test/kotlin/streams/StreamsTransactionEventHandlerTest.kt
+++ b/producer/src/test/kotlin/streams/StreamsTransactionEventHandlerTest.kt
@@ -16,6 +16,7 @@ import org.neo4j.graphdb.schema.ConstraintDefinition
 import org.neo4j.graphdb.schema.ConstraintType
 import org.neo4j.graphdb.schema.Schema
 import org.neo4j.kernel.internal.GraphDatabaseAPI
+import org.neo4j.logging.internal.NullLogService
 import streams.events.*
 import streams.mocks.MockStreamsEventRouter
 import kotlin.test.assertEquals
@@ -40,7 +41,7 @@ class StreamsTransactionEventHandlerTest {
         streamsConstraintsService = StreamsConstraintsService(dbMock, 0)
         streamsConstraintsService.start()
         handler = StreamsTransactionEventHandler(MockStreamsEventRouter(),
-                streamsConstraintsService, StreamsEventRouterConfiguration())
+                streamsConstraintsService, StreamsEventRouterConfiguration(), NullLogService.getInstance().nullLog)
         MockStreamsEventRouter.reset()
     }
 


### PR DESCRIPTION
Fixes #<>

transaction event message will be dropped when kafka goes offline

## Proposed Changes

A brief list of proposed changes in order to fix the issue:

  - write transaction to wal file
