### PR TITLE
ids bug fixed & add an node properties filter operator

### DIFF
--- a/producer/src/main/kotlin/streams/events/PreviousTransactionData.kt
+++ b/producer/src/main/kotlin/streams/events/PreviousTransactionData.kt
@@ -139,7 +139,7 @@ class PreviousTransactionDataBuilder {
                             .withId(it.id.toString())
                             .withName(it.type.name())
                             .withStartNode(it.startNode.id.toString(), startLabels, it.startNode.getProperties(*startNodeKeys))
-                            .withEndNode(it.endNode.id.toString(), endLabels, it.startNode.getProperties(*endNodeKeys))
+                            .withEndNode(it.endNode.id.toString(), endLabels, it.endNode.getProperties(*endNodeKeys))
                             .withBefore(beforeNode)
                             .withAfter(afterNode)
                             .build()


### PR DESCRIPTION
Fixes a bug with wrong 'ids' value in cdc when updating relationships
and
add node properties filter operator '@'

## Proposed Changes

A brief list of proposed changes in order to fix the issue:

  - add node properties filter operator '@', used like 
```
streams.source.topic.nodes.topic=User{-first_name,@gid};
```
  - PreviousTransactionData.kt `PreviousTransactionDataBuilder` class  `build` function `withEndNode` use startNode.getProperties() replace to endNode
